### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
 
   build-and-test:


### PR DESCRIPTION
Potential fix for [https://github.com/animeing/SoundOwl/security/code-scanning/3](https://github.com/animeing/SoundOwl/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Based on the provided workflow, the tasks (e.g., building a Docker image, listing files, and running tests) do not require write permissions. Therefore, we will set `contents: read` as the minimal permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
