### PR TITLE
Update MessageWindow styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -443,8 +443,9 @@ sw-save-message > * {
 }
 
 sw-save-message > div > input[type="text"] {
-  background: rgb(var(--v-theme-surface));
-  color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity));
+  background: rgb(var(--v-theme-background));
+  color: rgba(var(--v-theme-on-background), var(--v-high-emphasis-opacity));
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.38);
   font-size: 1em;
   vertical-align: top;
   height: 25px;

--- a/css/style.css
+++ b/css/style.css
@@ -401,11 +401,15 @@ sw-v-progress > div {
   text-shadow: var(--subcolor) 0 1px 1px 0;
 }
 
-#context-menu,
+#context-menu {
+  background: var(--subcolor);
+}
+
 sw-message-box,
 sw-message-button,
 sw-save-message {
-  background: var(--subcolor);
+  background: rgb(var(--v-theme-surface));
+  color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity));
 }
 
 sw-message-box,
@@ -439,7 +443,8 @@ sw-save-message > * {
 }
 
 sw-save-message > div > input[type="text"] {
-  background: var(--playerfcbgcolor);
+  background: rgb(var(--v-theme-surface));
+  color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity));
   font-size: 1em;
   vertical-align: top;
   height: 25px;
@@ -481,9 +486,9 @@ sw-save-message > div > input[type="text"] {
 sw-message-box > div > input[type="button"],
 sw-message-button > div > input[type="button"],
 sw-save-message > div > input[type="button"] {
-  background: rgba(0, 0, 0, 0);
+  background: rgba(var(--v-theme-surface), 0);
   border-radius: 1.5rem;
-  border: 1px solid #8e8e8e;
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.38);
   width: 10em;
   padding: 0 20px;
   margin: 0 5px;
@@ -492,7 +497,7 @@ sw-save-message > div > input[type="button"] {
 sw-message-box > div > input[type="button"]:hover,
 sw-message-button > div > input[type="button"]:hover,
 sw-save-message > div > input[type="button"]:hover {
-  background: rgba(131, 131, 131, 0.932);
+  background: rgba(var(--v-theme-on-surface), 0.08);
 }
 
 #footer {

--- a/frontend/src/base.js
+++ b/frontend/src/base.js
@@ -1912,9 +1912,6 @@ class OptionObject extends HTMLOptionElement{
 
 BaseFrameWork.defineCustomElement('sw-option', OptionObject, {extends:'option'});
 
-/**
- * @deprecated
- */
 export class MessageWindow extends HTMLElement{
   _messageElement = document.createElement('p');
   constructor(){
@@ -1932,8 +1929,12 @@ export class MessageWindow extends HTMLElement{
     return this._messageElement.innerText;
   }
 
-  open(){
+  open(viewTime = 0){
+    this.classList.remove('height-hide');
     fixed.appendChild(this);
+    if(viewTime > 0){
+      this.close(viewTime);
+    }
   }
 
   /**
@@ -1959,9 +1960,6 @@ export class MessageWindow extends HTMLElement{
 
 customElements.define('sw-message-box', MessageWindow);
 
-/**
- * @deprecated
- */
 export class MessageButtonWindow extends MessageWindow {
   _buttonNameList = new BaseFrameWork.List;
   constructor(){
@@ -2019,9 +2017,6 @@ export class MessageButtonWindow extends MessageWindow {
 
 customElements.define('sw-message-button', MessageButtonWindow);
 
-/**
- * @deprecated
- */
 export class InputMessageButtonWindow extends MessageButtonWindow {
   constructor(){
     super();


### PR DESCRIPTION
## Summary
- un-deprecate custom message components and add auto-close support
- adjust `sw-message*` styles to use Vuetify theme variables

## Testing
- `npm install --ignore-scripts` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_684d1f8371a08320bef825e76f01f664