### PR TITLE
Add playlist reorder support

### DIFF
--- a/api/update_playlist_order.php
+++ b/api/update_playlist_order.php
@@ -1,0 +1,36 @@
+<?php
+header("Content-Type: text/json");
+require_once(dirname(dirname(__FILE__)).'/parts/loader.php');
+
+if(!isset($_POST['playlist_name']) || !isset($_POST['sounds'])) {
+    http_response_code(400);
+    echo json_encode(['status'=>'error','detail'=>'invalid request']);
+    return;
+}
+
+$playlistName = $_POST['playlist_name'];
+$sounds = $_POST['sounds'];
+
+$playlistDao = new PlayListDao();
+$playlistDataDao = new PlaylistDataDao();
+
+$playlistDao->removePlayList($playlistName);
+
+$index = 0;
+foreach ($sounds as $hash) {
+    $playlist = new PlayListDto();
+    $playlist->setPlayList($playlistName);
+    $playlist->setSoundPoint($index);
+    $playlist->setSoundHash(ComplessUtil::decompless($hash));
+    $playlistDao->insert($playlist);
+    $index++;
+}
+
+foreach($playlistDataDao->find($playlistName) as $value){
+    $playlistDataDao->update($value);
+}
+
+echo json_encode([
+    'status'=>'success',
+    'detail'=>'playlist order saved.'
+]);

--- a/frontend/src/layout/footer/parts/CurrentAudioList.vue
+++ b/frontend/src/layout/footer/parts/CurrentAudioList.vue
@@ -51,7 +51,8 @@ export default {
       itemRefs: reactive({}),
       menuData: [
         { label: 'Clear playlist', action: () => audio.playList.clearPlaylist() },
-        { label: 'Save playlist', action: this.savePlaylistData }
+        { label: 'Save playlist', action: this.savePlaylistData },
+        { label: 'Save order', action: this.savePlaylistOrder }
       ],
       albumWidth: window.matchMedia('(max-width: 600px)').matches ? 54 : 108,
       albumHeight: window.matchMedia('(max-width: 600px)').matches ? 57.5 : 115,
@@ -69,6 +70,7 @@ export default {
   },
   mounted() {
     this.scrollToCurrentPlaying();
+    this.attachDragMove();
   },
   beforeDestroy() {
     audio.eventSupport.removeEventListener('audioSet', this.playChange);
@@ -80,6 +82,19 @@ export default {
     },
     soundContextMenuSelection(select, item) {
       select.action(item);
+    },
+    attachDragMove() {
+      this.$nextTick(() => {
+        for (const clip of this.soundClips) {
+          const el = this.itemRefs[clip.soundHash];
+          if (el && el.enableDragMove) {
+            el.setAttribute('d-group', 'current-playlist');
+            el.enableDragMove();
+            el.removeEventListener('dragend', this.onDragEnd);
+            el.addEventListener('dragend', this.onDragEnd);
+          }
+        }
+      });
     },
     savePlaylistData() {
       let messageWindow = document.createElement('sw-save-message');
@@ -123,6 +138,38 @@ export default {
       });
       messageWindow.open();
     },
+    savePlaylistOrder() {
+      let messageWindow = document.createElement('sw-save-message');
+      messageWindow.value = 'Save current order?\nPlease enter the playlist name.';
+      messageWindow.addItem('OK',()=>{
+        messageWindow.close();
+        let playlistName = messageWindow.inputText.value;
+        let action = new class extends BaseFrameWork.Network.RequestServerBase {
+          constructor() {
+            super(null, BASE.API+'update_playlist_order.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
+          }
+        };
+        action.formDataMap.append('playlist_name', playlistName);
+        for (const soundClip of this.soundClips) {
+          action.formDataMap.append('sounds[]', soundClip.soundHash);
+        }
+        action.httpRequestor.addEventListener('success', event=>{
+          let message = document.createElement('sw-message-button');
+          message.addItem('OK', ()=>{ message.close(); });
+          message.value = event.detail.response.detail;
+          if(event.detail.response.status == 'success'){ message.close(6000); }
+        });
+        action.httpRequestor.addEventListener('error', ()=>{
+          let message = document.createElement('sw-message-button');
+          message.addItem('OK', ()=>{ message.close(); });
+          message.value = `Action error ${action.httpRequestor.status}`;
+          message.open();
+        });
+        action.execute();
+      });
+      messageWindow.addItem('CANCEL',()=>{ messageWindow.close(); });
+      messageWindow.open();
+    },
     click(soundClip) {
       if (!soundClip) return; // soundClip が未定義の場合は何もしない
       if (audio.currentAudioClip?.equals(soundClip)) {
@@ -143,6 +190,7 @@ export default {
     },
     playlistUpdate() {
       this.soundClips = [...audio.playList];
+      this.attachDragMove();
       this.scrollToCurrentPlaying();
     },
     playChange() {
@@ -150,8 +198,27 @@ export default {
       this.scrollToCurrentPlaying();
     },
     setItemRef(el, item) {
-      if (el) this.itemRefs[item.soundHash] = el;
-      else delete this.itemRefs[item.soundHash];
+      if (el) {
+        this.itemRefs[item.soundHash] = el;
+        el.dataset.soundHash = item.soundHash;
+        el.setAttribute('d-group', 'current-playlist');
+        el.enableDragMove();
+        el.removeEventListener('dragend', this.onDragEnd);
+        el.addEventListener('dragend', this.onDragEnd);
+      } else {
+        const oldEl = this.itemRefs[item.soundHash];
+        if(oldEl){
+          oldEl.removeEventListener('dragend', this.onDragEnd);
+        }
+        delete this.itemRefs[item.soundHash];
+      }
+    },
+    onDragEnd() {
+      const container = this.$el.querySelector('#current-audio-list');
+      const orderedHashes = Array.from(container.querySelectorAll('[drag-item]')).map(el => el.dataset.soundHash);
+      const newList = orderedHashes.map(hash => this.soundClips.find(c => c.soundHash === hash)).filter(Boolean);
+      this.soundClips = newList;
+      audio.playList.updatePlaylist(newList);
     },
     scrollToCurrentPlaying() {
       if (!this.isView) return; // プレイリストが閉じている場合は何もしない


### PR DESCRIPTION
## Summary
- implement API endpoint `update_playlist_order.php` to save playlist order
- support drag reorder in `CurrentAudioList.vue`
- update playlist order in player and allow saving via context menu

## Testing
- `npm run build` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684ebb277ee88320b62a7104efd41360