### PR TITLE
Fix Dockerfile base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# 安定版のDebianをベースにしたPHPとApacheの最新イメージを使用
-FROM php:8.1-apache-buster
+# PHP 8.1 on a maintained Debian distribution
+FROM php:8.1-apache
 
 # リポジトリのキーを更新
 RUN apt-get update --allow-releaseinfo-change \


### PR DESCRIPTION
## Summary
- switch Dockerfile base to `php:8.1-apache` to fix apt repo errors

## Testing
- `bash test_scripts/docker_test.sh`


------
https://chatgpt.com/codex/tasks/task_e_687e3543da8c832099c207a196c1e1c6