### PR TITLE
Switch frontend to Express server

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+API_BASE_URL=http://localhost/api/

--- a/.github/workflows/frontend-server.yml
+++ b/.github/workflows/frontend-server.yml
@@ -1,0 +1,45 @@
+name: Frontend Server Test
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  start-front:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18.x
+
+    - name: Install server dependencies
+      run: npm install
+
+    - name: Install and build frontend
+      run: |
+        cd frontend
+        npm ci
+        npm run build
+
+    - name: Start server and check
+      run: |
+        node server.js &
+        SERVER_PID=$!
+        for i in {1..15}; do
+          if curl -s http://localhost:3000/ | grep -q '<body id="app">'; then
+            echo "Server responded"
+            kill $SERVER_PID
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "Server failed"
+        kill $SERVER_PID
+        exit 1
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /vendor/
 /api/lock/
 /frontend/node_modules
-/js/
+/js
+/node_modules
+/package-lock.json

--- a/FRONTEND_NODE_PLAN.md
+++ b/FRONTEND_NODE_PLAN.md
@@ -1,0 +1,16 @@
+# Frontend Node.js 移行方針
+
+このプロジェクトではフロントエンドをPHPの `index.php` からNode.jsに置き換えます。現在のPHP製APIはそのまま利用し、フロント専用のExpressサーバーを追加します。
+
+## 概要
+- ルートに `server.js` を配置し、Expressでフロント用HTMLと静的ファイルを配信します。
+- `parts/setting.ini` からWebSocketの再試行設定を読み込み、HTMLに注入します。
+- APIのエンドポイントは `.env` の `API_BASE_URL` で指定し、フロントからはその値を参照してリクエストを送信します。
+- フロントのVueアプリは `frontend/` 以下で開発し、Webpackで `js/main.bundle.js` を出力します。
+
+## 今後の作業
+1. `index.php` を段階的にExpressで置き換え、フロントのみNode.jsで動作させる。
+2. PHP製APIを残しつつ、必要に応じてAPI側もNode.jsへ移行検討。
+3. `.env` のAPI先を変更することでフロントとAPIの分離運用が可能となる。
+
+この方針によりフロントエンドとバックエンドを段階的に分離でき、既存のPHP APIを活かしつつNode.jsベースへの移行を進められます。

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ chmod 755 make.sh
 ![image](https://github.com/animeing/SoundOwl/assets/24301121/318e6bfa-c9ef-456a-86ea-f7f6796d55a4)
  - 設定を変更せずに "sound regist" ボタンを実行
 
+## Node.js フロントエンド移行方針
+フロントをPHPの`index.php`からNode.js(Express)へ段階的に移行します。詳細は`FRONTEND_NODE_PLAN.md`を参照してください。
+
 ## Function
 
 ### Equalizer

--- a/frontend/src/utilization/path.js
+++ b/frontend/src/utilization/path.js
@@ -3,6 +3,6 @@ export const BASE = {
   SAVE_PATH:window.location.href.split('#')[0],
   HOME:window.location.href.split('#')[0],
   VUE_HOME:window.location.href.split('#')[0]+'#/',
-  API:window.location.href.split('#')[0]+'api/',
+  API:process.env.API_BASE_URL || window.location.href.split('#')[0]+'api/',
   WEBSOCKET:window.location.hostname
 };

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const { DefinePlugin } = require('webpack');
+require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 const { VueLoaderPlugin } = require('vue-loader');
 const CircularDependencyPlugin = require('circular-dependency-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
@@ -54,7 +55,8 @@ module.exports = {
     new DefinePlugin({
       __VUE_OPTIONS_API__: true,
       __VUE_PROD_DEVTOOLS__: false,
-      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false
+      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false,
+      'process.env.API_BASE_URL': JSON.stringify(process.env.API_BASE_URL || '')
     }),
     new VueLoaderPlugin(),
     new CircularDependencyPlugin({

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "soundowl-server",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "dotenv": "^16.3.1",
+    "ini": "^3.0.1"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,67 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const ini = require('ini');
+require('dotenv').config();
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+// Load websocket settings from setting.ini
+let settings = {};
+try {
+  const iniPath = path.join(__dirname, 'parts', 'setting.ini');
+  settings = ini.parse(fs.readFileSync(iniPath, 'utf8'));
+} catch (err) {
+  console.warn('Could not read setting.ini:', err.message);
+}
+const retryCount = parseInt(settings.websocket_retry_count || 0, 10);
+const retryInterval = parseInt(settings.websocket_retry_interval || 10000, 10);
+
+app.use(express.static(path.join(__dirname)));
+
+// serve fontisto.ttf similar to img/fontisto.php
+app.get('/img/fontisto.php', (req, res) => {
+  const fontPath = path.join(__dirname, 'vendor', 'kenangundogan', 'fontisto', 'fonts', 'fontisto', 'fontisto.ttf');
+  res.type('font/ttf');
+  fs.createReadStream(fontPath).pipe(res);
+});
+
+app.get('/', (_req, res) => {
+  const style = fs.readFileSync(path.join(__dirname, 'css', 'style.css'), 'utf8');
+  const dark = fs.readFileSync(path.join(__dirname, 'css', 'dark-mode.css'), 'utf8');
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html;charset=UTF-8" >
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>
+@font-face {
+  font-family: 'Icon';
+  src: url(img/fontisto.php);
+}
+</style>
+<style>${style}</style>
+<style media="(prefers-color-scheme: dark)">${dark}</style>
+<script>
+const SoundOwlProperty = {};
+SoundOwlProperty.WebSocket = {
+    status:false,
+    retryCount:${retryCount},
+    retryInterval:${retryInterval}
+};
+</script>
+<link rel="icon" href="favicon.ico" sizes="any">
+<link rel="icon" href="favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="manifest.json">
+<script src="js/main.bundle.js" defer></script>
+</head>
+<body id="app"></body>
+</html>`;
+  res.send(html);
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add a simple Express server that replaces `index.php`
- allow frontend builds to pull API base URL from `.env`
- load env vars in webpack and use `API_BASE_URL` in JavaScript
- add basic Node dependencies

## Testing
- `npm install`
- `cd frontend && npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6882476a9bf0832083717f736cccde30