### PR TITLE
ci: fix invalid Node 28.x in webpack workflow

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -17,13 +17,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [24.x, 26.x, 28.x]
+        node-version: [22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
### Motivation
- The GitHub Actions job failed because the matrix included `28.x`, which is not available in the `setup-node` manifest for linux/x64 and caused the workflow to error before build steps.

### Description
- Update `.github/workflows/webpack.yml` to change the Node matrix from `[24.x, 26.x, 28.x]` to `[22.x, 24.x]` and bump `actions/setup-node` from `v3` to `v4` to use supported Node versions.

### Testing
- Verified the change with repository checks: `rg -n "28.x|setup-node|node-version" .github/workflows -S`, inspected the diff with `git diff`, and committed the update with `git commit`, all of which completed successfully; no CI workflow runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c5c41ffe48320ab2614b682269a57)