### PR TITLE
Introduce AudioPlaybackController to factor playback logic out of AudioPlayer

### DIFF
--- a/frontend/src/audio/AudioPlaybackController.js
+++ b/frontend/src/audio/AudioPlaybackController.js
@@ -1,0 +1,111 @@
+import { BaseFrameWork, setTitle } from '../base';
+import { AudioPlayStateEnum } from './enum/AudioPlayStateEnum';
+
+/**
+ * AudioPlayerから再生制御の責務を分離したコントローラー。
+ *
+ * AudioPlayerインスタンスを参照し、再生状態の遷移、
+ * 再生対象の差し替え、再生開始前の準備処理を実行する。
+ */
+export class AudioPlaybackController {
+  /**
+   * @param {import('./AudioPlayer').default} audioPlayer
+   */
+  constructor(audioPlayer) {
+    /**
+     * 再生処理を委譲する対象のAudioPlayer。
+     * @type {import('./AudioPlayer').default}
+     */
+    this.audioPlayer = audioPlayer;
+  }
+
+  /**
+   * 現在のオーディオクリップを差し替え、必要な再配置処理を行う。
+   *
+   * @param {import('./type/AudioClip').AudioClip} setAudioClip
+   */
+  setCurrentAudioClip(setAudioClip){
+    if(this.audioPlayer.playList.currentAudioClip === setAudioClip || setAudioClip == undefined){
+      return;
+    }
+    this.audioPlayer.playList.currentAudioClip = setAudioClip;
+    this.audioDeployment();
+  }
+
+  /**
+   * Audio要素へsrcを反映し、関連イベント発火とエフェクト初期化を行う。
+   */
+  audioDeployment(){
+    this.audioPlayer.eventSupport.dispatchEvent(new CustomEvent('audioSet'));
+    this.audioPlayer.audio.src = this.audioPlayer.playList.currentAudioClip.src;
+    this.audioPlayer.exAudioEffect.reset();
+  }
+
+  /**
+   * 指定クリップ（未指定時は現在クリップ）を再生する。
+   *
+   * 必要に応じてプレイリスト更新と音源準備を行い、
+   * 準備完了後に再生状態をPLAYへ遷移させる。
+   *
+   * @param {import('./type/AudioClip').AudioClip | undefined} audioClip
+   */
+  play(audioClip = undefined){
+    if(this.audioPlayer.audioEffectManager.audioContext == null) {
+      this.audioPlayer.initalize();
+    }
+    if(audioClip == undefined && this.audioPlayer.playList.currentAudioClip == undefined) {
+      return;
+    }
+    this.audioPlayer.audioPlayStateAction.lockEventTarget.action('setStopUpdate');
+    if(audioClip != undefined && this.audioPlayer.playList.findAudioClipPosition(audioClip) == -1) {
+      this.audioPlayer.playList.appendAudioClipNext(audioClip);
+      this.audioPlayer.playList.currentAudioClip = audioClip;
+      this.audioDeployment();
+    } else if( audioClip != undefined && (this.audioPlayer.playList.currentAudioClip == undefined || !this.audioPlayer.playList.currentAudioClip.equals(audioClip))) {
+      this.audioPlayer.playList.currentAudioClip = audioClip;
+      this.audioDeployment();
+    } else if(audioClip != undefined && audioClip.equals(this.audioPlayer.playList.currentAudioClip)) {
+      this.audioDeployment();
+    }
+
+    BaseFrameWork.waitForValue(
+      ()=>{
+        if(this.audioPlayer.loudnessNormalize.soundClip == null) {
+          return null;
+        }
+        return this.audioPlayer.loudnessNormalize.soundClip.src;
+      },
+      this.audioPlayer.playList.currentAudioClip.src,
+      2e5).
+      then(()=>{
+        setTitle(this.audioPlayer.playList.currentAudioClip.title);
+        this.audioPlayer.audio.play();
+        this.audioPlayer.audioPlayStateAction.currentPlayState = AudioPlayStateEnum.PLAY;
+        this.audioPlayer.eventSupport.dispatchEvent(new CustomEvent('play'));
+      }).finally(()=>{
+        this.audioPlayer.audioPlayStateAction.lockEventTarget.action('setUpdate');
+      });
+  }
+
+  /**
+   * 再生を一時停止し、再生状態をPAUSEへ遷移させる。
+   */
+  pause(){
+    this.audioPlayer.audio.pause();
+    this.audioPlayer.audioPlayStateAction.currentPlayState = AudioPlayStateEnum.PAUSE;
+    this.audioPlayer.eventSupport.dispatchEvent(new CustomEvent('pause'));
+  }
+
+  /**
+   * 再生を停止し、再生位置を先頭へ戻してSTOPへ遷移させる。
+   */
+  stop(){
+    if(this.audioPlayer.audio.src == null){
+      return;
+    }
+    this.audioPlayer.audio.pause();
+    this.audioPlayer.audio.currentTime = 0;
+    this.audioPlayer.audioPlayStateAction.currentPlayState = AudioPlayStateEnum.STOP;
+    this.audioPlayer.eventSupport.dispatchEvent(new CustomEvent('stop'));
+  }
+}

--- a/frontend/src/audio/AudioPlayer.js
+++ b/frontend/src/audio/AudioPlayer.js
@@ -1,7 +1,7 @@
-import { BaseFrameWork, setTitle, WakeLockManager } from '../base';
+import { WakeLockManager } from '../base';
 import { SoundInfomation } from '../page';
-import { AudioPlayStateEnum } from './enum/AudioPlayStateEnum';
 import { conversionToWav, ffmpegInitalize } from './conversionToWav';
+import { AudioPlayStateEnum } from './enum/AudioPlayStateEnum';
 import { Playlist } from './Playlist';
 import { AudioClip } from './type/AudioClip';
 import { LoudnessNormalizeComponent } from './effect/normalize/LoudnessNormalizeComponent';
@@ -11,6 +11,7 @@ import { AudioEffectManager } from './effect/AudioComponentManager';
 import { ImpulseResponseEffect } from './effect/effect3d/ImpulseResponseEffect';
 import { VolumeComponent } from './effect/volume/VolumeComponent';
 import { AudioPlayStateAction } from './AudioPlayStateAction';
+import { AudioPlaybackController } from './AudioPlaybackController';
 
 class AudioPlayer{
   constructor(){
@@ -72,6 +73,8 @@ class AudioPlayer{
       request.execute();
     });
 
+    this.playbackController = new AudioPlaybackController(this);
+
     this.audioPlayStateAction.lockEventTarget.action('setUpdate');
   }
 
@@ -116,7 +119,7 @@ class AudioPlayer{
 
   /**
    * @deprecated
-   * @use AudioPlayer.AudioPlayStateAction.currentPlayState
+   * @use AudioPlayer.audioPlayStateAction.currentPlayState
    */
   get currentPlayState(){
     return this.audioPlayStateAction.currentPlayState;
@@ -127,28 +130,25 @@ class AudioPlayer{
   }
 
   /**
-     * 
-     * @param {AudioClip} setAudioClip 
-     */
+   * @deprecated
+   * @use AudioPlayer.playbackController.setCurrentAudioClip
+   */
   setCurrentAudioClip(setAudioClip){
-    if(this.playList.currentAudioClip === setAudioClip || setAudioClip == undefined){
-      return;
-    }
-    this.playList.currentAudioClip = setAudioClip;
-    this.audioDeployment();
-    // this.audioUpdate(); //CHECK
+    this.playbackController.setCurrentAudioClip(setAudioClip);
   }
 
+  /**
+   * @deprecated
+   * @use AudioPlayer.playbackController.audioDeployment
+   */
   audioDeployment(){
-    this.eventSupport.dispatchEvent(new CustomEvent('audioSet'));
-    this.audio.src = this.playList.currentAudioClip.src;
-    this.exAudioEffect.reset();
+    this.playbackController.audioDeployment();
   }
 
 
   /**
    * @deprecated
-   * @use AudioPlayer.AudioPlayStateAction.isError
+   * @use AudioPlayer.audioPlayStateAction.isError
    */
   get isError(){
     return this.audioPlayStateAction.isError;
@@ -156,7 +156,7 @@ class AudioPlayer{
 
   /**
    * @deprecated
-   * @use AudioPlayer.AudioPlayStateAction.isLoading
+   * @use AudioPlayer.audioPlayStateAction.isLoading
    */
   get isLoading(){
     return this.audioPlayStateAction.isLoading;
@@ -164,70 +164,34 @@ class AudioPlayer{
   
   /**
    * @deprecated
-   * @use AudioPlayer.AudioPlayStateAction.isPlaying
+   * @use AudioPlayer.audioPlayStateAction.isPlaying
    */
   get isPlaying(){
     return this.audioPlayStateAction.isPlaying;
   }
 
   /**
-   * 指定されたオーディオクリップを再生します。引数が未指定の場合、現在選択されているオーディオクリップを再生します。
-   * 引数で指定されたオーディオクリップがプレイリストに存在しない場合、プレイリストの次の位置に追加してから再生します。
-   * 指定されたオーディオクリップが現在のオーディオクリップと異なる場合、そのクリップを現在のオーディオクリップとして設定してから再生します。
-   * 引数が未指定で現在のオーディオクリップも未定義の場合は、何もしません。
-   * この関数は、オーディオの準備が整い次第再生を開始し、タイトルの設定と再生イベントの発火を行います。
-   * @param {AudioClip} audioClip - 再生するオーディオクリップ。未指定の場合、現在のオーディオクリップが使用されます。
+   * @deprecated
+   * @use AudioPlayer.playbackController.play
    */
   play(audioClip = undefined){
-    if(this.audioEffectManager.audioContext == null) {
-      this.initalize();
-    }
-    if(audioClip == undefined && this.playList.currentAudioClip == undefined) {
-      return;
-    }
-    this.audioPlayStateAction.lockEventTarget.action('setStopUpdate');
-    if(audioClip != undefined && this.playList.findAudioClipPosition(audioClip) == -1) {
-      this.playList.appendAudioClipNext(audioClip);
-      this.playList.currentAudioClip = audioClip;
-      this.audioDeployment();
-    } else if( audioClip != undefined && (this.playList.currentAudioClip == undefined || !this.playList.currentAudioClip.equals(audioClip))) {
-      this.playList.currentAudioClip = audioClip;
-      this.audioDeployment();
-    } else if(audioClip != undefined && audioClip.equals(this.playList.currentAudioClip)) {
-      this.audioDeployment();
-    }
+    this.playbackController.play(audioClip);
+  }
 
-    BaseFrameWork.waitForValue(
-      ()=>{
-        if(this.loudnessNormalize.soundClip == null) {
-          return null;
-        }
-        return this.loudnessNormalize.soundClip.src;
-      },
-      this.playList.currentAudioClip.src,
-      2e5).
-      then(()=>{
-        setTitle(this.playList.currentAudioClip.title);
-        this.audio.play();
-        this.audioPlayStateAction.currentPlayState = AudioPlayStateEnum.PLAY;
-        this.eventSupport.dispatchEvent(new CustomEvent('play'));
-      }).finally(()=>{
-        this.audioPlayStateAction.lockEventTarget.action('setUpdate');
-      });
-  }
+  /**
+   * @deprecated
+   * @use AudioPlayer.playbackController.pause
+   */
   pause(){
-    this.audio.pause();
-    this.audioPlayStateAction.currentPlayState = AudioPlayStateEnum.PAUSE;
-    this.eventSupport.dispatchEvent(new CustomEvent('pause'));
+    this.playbackController.pause();
   }
+
+  /**
+   * @deprecated
+   * @use AudioPlayer.playbackController.stop
+   */
   stop(){
-    if(this.audio.src == null){
-      return;
-    }
-    this.audio.pause();
-    this.audio.currentTime = 0;
-    this.audioPlayStateAction.currentPlayState = AudioPlayStateEnum.STOP;
-    this.eventSupport.dispatchEvent(new CustomEvent('stop'));
+    this.playbackController.stop();
   }
 }
 


### PR DESCRIPTION
### Motivation
- Separate playback control responsibilities from `AudioPlayer` to improve cohesion and make playback flow easier to test and maintain.
- Provide a single controller for audio clip selection, deployment, and state transitions while keeping backward-compatible APIs on `AudioPlayer`.

### Description
- Add `frontend/src/audio/AudioPlaybackController.js` implementing clip selection, deployment, `play`, `pause`, and `stop` logic and using `BaseFrameWork.waitForValue` and `setTitle` for playback preparation.
- Wire a `playbackController` into `AudioPlayer` and delegate playback-related methods (`play`, `pause`, `stop`, `audioDeployment`, `setCurrentAudioClip`) to the new controller while leaving deprecated wrappers on `AudioPlayer`.
- Update imports and JSDoc notes in `AudioPlayer` to reference `audioPlayStateAction` and mark moved APIs as `@deprecated` with `@use` pointers to the controller.
- Preserve existing event dispatches and effect initialization by invoking the same behavior from the controller, and keep `initalize` and effect setup in `AudioPlayer` intact.

### Testing
- Ran the existing frontend automated test suite with `yarn test`, and all tests completed successfully.
- Ran linting with `yarn lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10fe1062b083209a56646b9783428b)