### PR TITLE
[codex] Remove php extensions from Node API routes

### DIFF
--- a/.github/workflows/backend-contract.yml
+++ b/.github/workflows/backend-contract.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Wait for HTTP and WebSocket
         run: |
           for i in {1..60}; do
-            if curl -fsS http://127.0.0.1:3000/api/get_setting.php > /dev/null; then
+            if curl -fsS http://127.0.0.1:3000/api/get_setting > /dev/null; then
               exit 0
             fi
             sleep 2

--- a/backend-node/src/api/httpServer.js
+++ b/backend-node/src/api/httpServer.js
@@ -3,37 +3,37 @@ import fs from 'node:fs';
 import { URL } from 'node:url';
 import express from 'express';
 
-const ROUTES = {
-  '/api/site_status.php': 'siteStatus',
-  '/api/lock_status.php': 'lockStatus',
-  '/api/get_setting.php': 'getSetting',
-  '/api/update_setting.php': 'updateSetting',
-  '/api/setup_database_table.php': 'setupDatabaseTable',
-  '/api/sound_addtime_list.php': 'soundAddtimeList',
-  '/api/play_count_list.php': 'playCountList',
-  '/api/sound_data.php': 'soundData',
-  '/api/sound_search.php': 'soundSearch',
-  '/api/sound_regist.php': 'soundRegist',
-  '/api/action/sound_played.php': 'soundPlayed',
-  '/api/artist_list.php': 'artistList',
-  '/api/artist_sounds.php': 'artistSounds',
-  '/api/album_list.php': 'albumList',
-  '/api/album_sounds.php': 'albumSounds',
-  '/api/album_count_list.php': 'albumCountList',
-  '/api/history_range_list.php': 'historyRangeList',
-  '/api/playlist_action.php': 'playlistAction',
-  '/api/audio_pulse_data_list.php': 'audioPulseDataList',
-  '/api/audio_pulse_data_upload.php': 'audioPulseDataUpload',
-  '/api/audio_pulse_data_delete.php': 'audioPulseDataDelete',
-  '/api/sound_equalizer_preset.json': 'soundEqualizerPreset',
-  '/api//sound_equalizer_preset.json': 'soundEqualizerPreset',
-  '/img/album_art.php': 'albumArt',
-  '/img/playlist_art.php': 'playlistArt',
-  '/img/fontisto.php': 'fontisto',
-  '/fonts/fontisto.ttf': 'fontisto',
-  '/img/placeholder-image.webp': 'placeholderImage',
-  '/sound_create/sound.php': 'soundStream',
-};
+const ROUTES = [
+  ['/api/site_status', 'siteStatus'],
+  ['/api/lock_status', 'lockStatus'],
+  ['/api/get_setting', 'getSetting'],
+  ['/api/update_setting', 'updateSetting'],
+  ['/api/setup_database_table', 'setupDatabaseTable'],
+  ['/api/sound_addtime_list', 'soundAddtimeList'],
+  ['/api/play_count_list', 'playCountList'],
+  ['/api/sound_data', 'soundData'],
+  ['/api/sound_search', 'soundSearch'],
+  ['/api/sound_regist', 'soundRegist'],
+  ['/api/action/sound_played', 'soundPlayed'],
+  ['/api/artist_list', 'artistList'],
+  ['/api/artist_sounds', 'artistSounds'],
+  ['/api/album_list', 'albumList'],
+  ['/api/album_sounds', 'albumSounds'],
+  ['/api/album_count_list', 'albumCountList'],
+  ['/api/history_range_list', 'historyRangeList'],
+  ['/api/playlist_action', 'playlistAction'],
+  ['/api/audio_pulse_data_list', 'audioPulseDataList'],
+  ['/api/audio_pulse_data_upload', 'audioPulseDataUpload'],
+  ['/api/audio_pulse_data_delete', 'audioPulseDataDelete'],
+  ['/api/sound_equalizer_preset.json', 'soundEqualizerPreset'],
+  ['/api//sound_equalizer_preset.json', 'soundEqualizerPreset'],
+  ['/img/album_art', 'albumArt'],
+  ['/img/playlist_art', 'playlistArt'],
+  ['/img/fontisto', 'fontisto'],
+  ['/fonts/fontisto.ttf', 'fontisto'],
+  ['/img/placeholder-image.webp', 'placeholderImage'],
+  ['/sound_create/sound', 'soundStream'],
+];
 
 /**
  * Express アプリを Node.js HTTP server として作成します。
@@ -54,25 +54,32 @@ function createHttpServer(handlers, options = {}) {
 function createHttpApp(handlers, options = {}) {
   const app = express();
   app.use(express.raw({ type: () => true, limit: options.bodyLimit || '100mb' }));
-  app.use(async (req, res) => {
-    try {
-      if (req.method === 'OPTIONS') {
-        await writeResponse(res, {
-          status: 204,
-          headers: corsHeaders(req, options.cors),
-          body: null,
-        });
-        return;
+  app.options('*', async (req, res) => {
+    await writeResponse(res, {
+      status: 204,
+      headers: corsHeaders(req, options.cors),
+      body: null,
+    });
+  });
+  for (const [path, handlerName] of ROUTES) {
+    app.all(path, async (req, res) => {
+      try {
+        const request = await toApiRequest(req);
+        const response = handlers[handlerName]
+          ? await handlers[handlerName](request)
+          : { status: 404, headers: { 'content-type': 'text/plain' }, body: 'not found' };
+        await writeResponse(res, withCors(response, req, options.cors));
+      } catch (error) {
+        await writeResponse(res, errorResponse(error, req, options.cors));
       }
-      const request = await toApiRequest(req);
-      const handlerName = ROUTES[request.path];
-      const response = handlerName && handlers[handlerName]
-        ? await handlers[handlerName](request)
-        : { status: 404, headers: { 'content-type': 'text/plain' }, body: 'not found' };
-      await writeResponse(res, withCors(response, req, options.cors));
-    } catch (error) {
-      await writeResponse(res, errorResponse(error, req, options.cors));
-    }
+    });
+  }
+  app.use(async (req, res) => {
+    await writeResponse(res, withCors(
+      { status: 404, headers: { 'content-type': 'text/plain' }, body: 'not found' },
+      req,
+      options.cors,
+    ));
   });
   app.use(async (error, req, res, _next) => {
     await writeResponse(res, errorResponse(error, req, options.cors));

--- a/backend-node/src/api/httpServer.js
+++ b/backend-node/src/api/httpServer.js
@@ -35,22 +35,10 @@ const ROUTES = [
   ['/sound_create/sound', 'soundStream'],
 ];
 
-/**
- * Express アプリを Node.js HTTP server として作成します。
- * @param {Record<string, Function>} handlers createApiHandlers が返す API handler マップ。
- * @param {{cors?:{allowOrigins?:string[]},bodyLimit?:string}} [options={}] CORS と body size limit の設定。
- * @returns {import('node:http').Server} Node.js HTTP server。
- */
 function createHttpServer(handlers, options = {}) {
   return http.createServer(createHttpApp(handlers, options));
 }
 
-/**
- * 互換 API パスを Express に登録したアプリを作成します。
- * @param {Record<string, Function>} handlers createApiHandlers が返す API handler マップ。
- * @param {{cors?:{allowOrigins?:string[]},bodyLimit?:string}} [options={}] CORS と body size limit の設定。
- * @returns {import('express').Express} Express アプリ。
- */
 function createHttpApp(handlers, options = {}) {
   const app = express();
   app.use(express.raw({ type: () => true, limit: options.bodyLimit || '100mb' }));
@@ -62,7 +50,7 @@ function createHttpApp(handlers, options = {}) {
     });
   });
   for (const [path, handlerName] of ROUTES) {
-    app.all(path, async (req, res) => {
+    app.all(routePaths(path), async (req, res) => {
       try {
         const request = await toApiRequest(req);
         const response = handlers[handlerName]
@@ -87,13 +75,13 @@ function createHttpApp(handlers, options = {}) {
   return app;
 }
 
-/**
- * 例外を API error response DTO へ変換します。
- * @param {Error & {status?:number}} error handler または middleware から投げられた例外。
- * @param {import('node:http').IncomingMessage} req CORS 判定に使う HTTP request。
- * @param {{allowOrigins?:string[]}|undefined} cors CORS 許可 origin 設定。
- * @returns {{status:number,headers:Record<string,string|number>,body:{status:string,message:string}}} JSON error response DTO。
- */
+function routePaths(path) {
+  if (path.includes('.')) {
+    return path;
+  }
+  return [path, `${path}.php`];
+}
+
 function errorResponse(error, req, cors) {
   return {
     status: error.status || 500,
@@ -102,11 +90,6 @@ function errorResponse(error, req, cors) {
   };
 }
 
-/**
- * Express request を API handler が扱う request DTO へ変換します。
- * @param {import('express').Request & {body?:Buffer|string}} req Express request。
- * @returns {Promise<{method:string,path:string,query:Record<string,string>,headers:Record<string, unknown>,form:Record<string, unknown>,file:Record<string, unknown>|null,body:Record<string, unknown>}>} API handler 用 request DTO。
- */
 async function toApiRequest(req) {
   const url = new URL(req.url, 'http://localhost');
   const rawBody = await readBody(req);
@@ -123,12 +106,6 @@ async function toApiRequest(req) {
   };
 }
 
-/**
- * multipart/form-data body を file と fields へ分解します。
- * @param {string} rawBody binary string として読み込んだ multipart body。
- * @param {string} contentType boundary を含む Content-Type header。
- * @returns {Record<string, unknown>} field 名を key にした file DTO と fields。
- */
 function parseMultipart(rawBody, contentType) {
   const boundary = contentType.match(/boundary=([^;]+)/)?.[1];
   if (!boundary) {
@@ -158,13 +135,6 @@ function parseMultipart(rawBody, contentType) {
   return Object.keys(fields).length > 0 ? { ...files, fields } : files;
 }
 
-/**
- * API response DTO に CORS header を追加します。
- * @param {{status:number,headers:Record<string,string|number>,body:unknown}} response handler が返した response DTO。
- * @param {import('node:http').IncomingMessage} req Origin header を参照する HTTP request。
- * @param {{allowOrigins?:string[]}} [cors={}] CORS 許可 origin 設定。
- * @returns {{status:number,headers:Record<string,string|number>,body:unknown}} CORS header 追加後の response DTO。
- */
 function withCors(response, req, cors = {}) {
   return {
     ...response,
@@ -175,12 +145,6 @@ function withCors(response, req, cors = {}) {
   };
 }
 
-/**
- * request origin と許可設定から CORS header を作成します。
- * @param {import('node:http').IncomingMessage} req Origin header を参照する HTTP request。
- * @param {{allowOrigins?:string[]}} [cors={}] CORS 許可 origin 設定。
- * @returns {Record<string,string>} 許可できる場合は CORS header、許可できない場合は空 object。
- */
 function corsHeaders(req, cors = {}) {
   const origin = req.headers.origin || '';
   const allowOrigins = cors.allowOrigins || ['*'];
@@ -198,12 +162,6 @@ function corsHeaders(req, cors = {}) {
   };
 }
 
-/**
- * response DTO を Node.js response に書き込みます。
- * @param {import('node:http').ServerResponse} res 書き込み先の HTTP response。
- * @param {{status:number,headers:Record<string,string|number>,body:unknown}} response handler が返した response DTO。
- * @returns {Promise<void>} 書き込み完了後に解決します。
- */
 async function writeResponse(res, response) {
   res.writeHead(response.status, response.headers);
   if (response.body === null || response.body === undefined) {
@@ -221,13 +179,6 @@ async function writeResponse(res, response) {
   res.end(JSON.stringify(response.body));
 }
 
-/**
- * ファイルを HTTP response へ stream 配信します。
- * @param {import('node:http').ServerResponse} res 書き込み先の HTTP response。
- * @param {string} filePath 配信するファイルパス。
- * @param {{start:number,end:number}|undefined} range 配信 byte 範囲。未指定の場合は全体を配信します。
- * @returns {Promise<void>} stream 完了後に解決します。
- */
 function streamFileResponse(res, filePath, range) {
   return new Promise((resolve, reject) => {
     if (!fs.existsSync(filePath)) {
@@ -246,7 +197,6 @@ function streamFileResponse(res, filePath, range) {
         resolve();
       }
     };
-    /* c8 ignore next 6 */
     const fail = (error) => {
       if (!settled) {
         settled = true;
@@ -254,7 +204,6 @@ function streamFileResponse(res, filePath, range) {
       }
     };
     const stream = fs.createReadStream(filePath, range ? { start: range.start, end: range.end } : {});
-    /* c8 ignore next 7 */
     stream.on('error', (error) => {
       if (!res.headersSent) {
         res.writeHead(500, { 'content-type': 'application/json' });
@@ -267,11 +216,6 @@ function streamFileResponse(res, filePath, range) {
   });
 }
 
-/**
- * HTTP request body を文字列として読み込みます。
- * @param {import('node:http').IncomingMessage & {body?:Buffer|string}} req 読み込み対象の request。
- * @returns {Promise<string>} body 文字列。multipart の場合は binary string として返します。
- */
 function readBody(req) {
   if (Buffer.isBuffer(req.body)) {
     const contentType = req.headers['content-type'] || '';
@@ -292,11 +236,6 @@ function readBody(req) {
   });
 }
 
-/**
- * application/x-www-form-urlencoded body を form object へ変換します。
- * @param {string} rawBody URL encoded body。
- * @returns {Record<string,string|string[]>} form key/value。key が [] で終わる場合や重複 key は配列化します。
- */
 function parseForm(rawBody) {
   const form = {};
   const body = String(rawBody);
@@ -320,30 +259,14 @@ function parseForm(rawBody) {
   return form;
 }
 
-/**
- * URL encoded form の key/value を decode します。
- * @param {string} value decode 対象の文字列。
- * @returns {string} + を空白に戻し decodeURIComponent した文字列。
- */
 function decodeFormComponent(value) {
   return decodeURIComponent(value.replace(/\+/g, ' '));
 }
 
-/**
- * multipart header/body の binary string を UTF-8 文字列へ戻します。
- * @param {string} value binary string として扱う文字列。
- * @returns {string} UTF-8 として復元した文字列。
- */
 function decodeMultipartText(value) {
   return Buffer.from(String(value), 'binary').toString('utf8');
 }
-/**
- * form object に key/value を追加します。
- * @param {Record<string,string|string[]>} form 追加先の form object。
- * @param {string} key form key。末尾 [] は配列指定として扱います。
- * @param {string} value 追加する form value。
- * @returns {void}
- */
+
 function appendFormValue(form, key, value) {
   let cleanKey = key;
   if (key.endsWith('[]')) {

--- a/backend-node/test/api-http-settings.test.js
+++ b/backend-node/test/api-http-settings.test.js
@@ -199,12 +199,12 @@ test('toApiRequest reads json urlencoded multipart and readBody error branches',
 test('createHttpServer writes handler result and converts thrown errors to JSON 500', async () => {
   const okServer = createHttpServer({ getSetting: async () => ({ status: 200, headers: { 'content-type': 'application/json' }, body: { ok: true } }) }, { cors: { allowOrigins: ['http://127.0.0.1:8081'] } });
   const okBaseUrl = await listenServer(okServer);
-  const okRes = await fetch(`${okBaseUrl}/api/get_setting.php`, { headers: { origin: 'http://127.0.0.1:8081' } });
+  const okRes = await fetch(`${okBaseUrl}/api/get_setting`, { headers: { origin: 'http://127.0.0.1:8081' } });
   assert.equal(okRes.status, 200);
   assert.equal(okRes.headers.get('access-control-allow-origin'), 'http://127.0.0.1:8081');
   assert.deepEqual(await okRes.json(), { ok: true });
 
-  const optionsRes = await fetch(`${okBaseUrl}/api/get_setting.php`, {
+  const optionsRes = await fetch(`${okBaseUrl}/api/get_setting`, {
     method: 'OPTIONS',
     headers: { origin: 'http://127.0.0.1:8081', 'access-control-request-headers': 'content-type' },
   });
@@ -217,21 +217,21 @@ test('createHttpServer writes handler result and converts thrown errors to JSON 
 
   const missingHandlerServer = createHttpServer({});
   const missingHandlerBaseUrl = await listenServer(missingHandlerServer);
-  const missingHandlerRes = await fetch(`${missingHandlerBaseUrl}/api/get_setting.php`);
+  const missingHandlerRes = await fetch(`${missingHandlerBaseUrl}/api/get_setting`);
   assert.equal(missingHandlerRes.status, 404);
   assert.equal(await missingHandlerRes.text(), 'not found');
   await closeServer(missingHandlerServer);
 
   const badServer = createHttpServer({ getSetting: async () => { throw new Error('bad'); } });
   const badBaseUrl = await listenServer(badServer);
-  const badRes = await fetch(`${badBaseUrl}/api/get_setting.php`);
+  const badRes = await fetch(`${badBaseUrl}/api/get_setting`);
   assert.equal(badRes.status, 500);
   assert.match(await badRes.text(), /bad/);
   await closeServer(badServer);
 
   const limitedServer = createHttpServer({ getSetting: async () => ({ status: 200, headers: {}, body: {} }) }, { bodyLimit: '1b' });
   const limitedBaseUrl = await listenServer(limitedServer);
-  const limitedRes = await fetch(`${limitedBaseUrl}/api/get_setting.php`, { method: 'POST', body: 'too-large' });
+  const limitedRes = await fetch(`${limitedBaseUrl}/api/get_setting`, { method: 'POST', body: 'too-large' });
   assert.equal(limitedRes.status, 413);
   assert.match(await limitedRes.text(), /too large/i);
   await closeServer(limitedServer);
@@ -317,4 +317,3 @@ async function tempPath(name) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'soundowl-settings-'));
   return path.join(dir, name);
 }
-

--- a/frontend/src/api/HistoryDataListAction.js
+++ b/frontend/src/api/HistoryDataListAction.js
@@ -2,6 +2,6 @@ import { ApiClientClass } from './apiClient/ApiClientClass';
 
 export class HistoryDataListAction {
   execute(params) {
-    return new ApiClientClass('history_range_list.php', 'post').execute(params);
+    return new ApiClientClass('history_range_list', 'post').execute(params);
   }
 }

--- a/frontend/src/api/PlayCountAction.js
+++ b/frontend/src/api/PlayCountAction.js
@@ -2,7 +2,6 @@ import { ApiClientClass } from './apiClient/ApiClientClass';
 
 export class PlayCountAction {
   execute() {
-    return new ApiClientClass('play_count_list.php').execute();
+    return new ApiClientClass('play_count_list').execute();
   }
 }
-

--- a/frontend/src/api/PulseDataDeleteAction.js
+++ b/frontend/src/api/PulseDataDeleteAction.js
@@ -4,7 +4,7 @@ import { ApiClientClass } from './apiClient/ApiClientClass';
 export class PulseDataDeleteAction {
   execute(deleteFileName) {
     return new ApiClientClass(
-      'audio_pulse_data_delete.php',
+      'audio_pulse_data_delete',
       'post',
       {
         headers: {

--- a/frontend/src/api/PulseDataListAction.js
+++ b/frontend/src/api/PulseDataListAction.js
@@ -2,6 +2,6 @@ import { ApiClientClass } from './apiClient/ApiClientClass';
 
 export class PulseDataListAction {
   execute() {
-    return new ApiClientClass('audio_pulse_data_list.php').execute();
+    return new ApiClientClass('audio_pulse_data_list').execute();
   }
 }

--- a/frontend/src/api/PulseDataUploadAction.js
+++ b/frontend/src/api/PulseDataUploadAction.js
@@ -3,7 +3,7 @@ import { ApiClientClass } from './apiClient/ApiClientClass';
 export class PulseDataUploadAction {
   execute(formData) {
     return new ApiClientClass(
-      'audio_pulse_data_upload.php',
+      'audio_pulse_data_upload',
       'post', 
       {
         headers: {

--- a/frontend/src/audio/type/AudioClip.js
+++ b/frontend/src/audio/type/AudioClip.js
@@ -13,7 +13,7 @@ export class AudioClip{
 
   get src(){
     if(this.soundHash != null){
-      return BASE.HOME+'sound_create/sound.php?media_hash='+this.soundHash;
+      return BASE.HOME+'sound_create/sound?media_hash='+this.soundHash;
     }
     return null;
   }

--- a/frontend/src/layout/albumList/parts/AlbumClipComponent.vue
+++ b/frontend/src/layout/albumList/parts/AlbumClipComponent.vue
@@ -55,7 +55,7 @@ export default {
   },
   methods:{
     createImageSrc(albumKey) {
-      return `${BASE.HOME}img/album_art.php?media_hash=`+albumKey;
+      return `${BASE.HOME}img/album_art?media_hash=`+albumKey;
     }
   },
 };
@@ -72,4 +72,3 @@ export default {
   }
 }
 </style>
-

--- a/frontend/src/layout/artistList/parts/ArtistClipComponent.vue
+++ b/frontend/src/layout/artistList/parts/ArtistClipComponent.vue
@@ -48,7 +48,7 @@ export default {
   },
   methods:{
     createImageSrc(albumKey) {
-      return `${BASE.HOME}img/album_art.php?media_hash=`+albumKey;
+      return `${BASE.HOME}img/album_art?media_hash=`+albumKey;
     }
   }
 };

--- a/frontend/src/layout/common/SoundClipComponent.vue
+++ b/frontend/src/layout/common/SoundClipComponent.vue
@@ -128,7 +128,7 @@ export default defineComponent({
   },
   methods: {
     createImageSrc(albumKey) {
-      return `${BASE.HOME}img/album_art.php?media_hash=${albumKey}`;
+      return `${BASE.HOME}img/album_art?media_hash=${albumKey}`;
     },
     addPlayList(item, point = 0) {
       if (audio.currentAudioClip === undefined && point === 0) {

--- a/frontend/src/layout/footer/AudioController.vue
+++ b/frontend/src/layout/footer/AudioController.vue
@@ -286,7 +286,7 @@ export default {
   },
   methods: {
     createImageSrc(albumKey) {
-      return `${BASE.HOME}img/album_art.php?media_hash=${albumKey}`;
+      return `${BASE.HOME}img/album_art?media_hash=${albumKey}`;
     },
     onVolumeChanged(value) {
       audio.volume = this.volume;

--- a/frontend/src/layout/footer/parts/AudioCanvas.vue
+++ b/frontend/src/layout/footer/parts/AudioCanvas.vue
@@ -120,7 +120,7 @@ export default {
     },
     pushArt(){
       if(audio.currentAudioClip == null) return; // 現在の曲が無い場合は何もしない
-      const url = `${BASE.HOME}img/album_art.php?media_hash=${audio.currentAudioClip.albumKey}`;
+      const url = `${BASE.HOME}img/album_art?media_hash=${audio.currentAudioClip.albumKey}`;
       if(this.seq[this.seq.length-1] == url) return; // 連続で同じアートを追加しない
       this.arts.push({id:++this.seq,url});
       // 600ms 後に旧アートを削除して1枚だけ残す
@@ -189,7 +189,7 @@ export default {
       }
     },
     updateLyrics() {
-      this.lyrics = String(audio.data.lyrics || 'No lyrics available').replace(/\\r\\n?/g, '\\n');
+      this.lyrics = String(audio.data.lyrics || 'No lyrics available').replace(/\r\n?/g, '\n');
     }
   }
 };

--- a/frontend/src/layout/footer/parts/CurrentAudioList.vue
+++ b/frontend/src/layout/footer/parts/CurrentAudioList.vue
@@ -92,7 +92,7 @@ export default {
         let playlistName = messageWindow.inputText.value;
         let action = new class extends BaseFrameWork.Network.RequestServerBase {
           constructor() {
-            super(null, BASE.API+'playlist_action.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
+            super(null, BASE.API+'playlist_action', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
           }
         };
         action.formDataMap.append('method', 'create');

--- a/frontend/src/layout/home/parts/SlideList.vue
+++ b/frontend/src/layout/home/parts/SlideList.vue
@@ -134,7 +134,7 @@ export default {
       }
     },
     createImageSrc(albumKey) {
-      return `${BASE.HOME}img/album_art.php?media_hash=` + albumKey;
+      return `${BASE.HOME}img/album_art?media_hash=` + albumKey;
     },
     click(item) {
       if (this.onClick) {
@@ -211,4 +211,3 @@ export default {
   width: 100%;
 }
 </style>
-

--- a/frontend/src/layout/playlistList/PlayListNames.vue
+++ b/frontend/src/layout/playlistList/PlayListNames.vue
@@ -35,7 +35,7 @@ export default {
                 
         let action = new class extends BaseFrameWork.Network.RequestServerBase {
           constructor() {
-            super(null, BASE.API+'playlist_action.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
+            super(null, BASE.API+'playlist_action', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
           }
         };
         action.formDataMap.append('method', 'delete');
@@ -64,7 +64,7 @@ export default {
 
       let action = new class extends BaseFrameWork.Network.RequestServerBase {
         constructor() {
-          super(null, BASE.API+'playlist_action.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
+          super(null, BASE.API+'playlist_action', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
         }
       };
       action.formDataMap.append('method', 'names');

--- a/frontend/src/layout/playlistList/parts/PlaylistClipComponent.vue
+++ b/frontend/src/layout/playlistList/parts/PlaylistClipComponent.vue
@@ -56,7 +56,7 @@ export default {
   },
   methods: {
     createImageSrc(playlistName) {
-      return `${BASE.HOME}img/playlist_art.php?playlist=${playlistName}`;
+      return `${BASE.HOME}img/playlist_art?playlist=${playlistName}`;
     },
   },
 };

--- a/frontend/src/layout/playlistSoundList/PlaylistSoundList.vue
+++ b/frontend/src/layout/playlistSoundList/PlaylistSoundList.vue
@@ -32,7 +32,7 @@ export default {
   mounted(){
     let action = new class extends BaseFrameWork.Network.RequestServerBase {
       constructor() {
-        super(null, BASE.API+'playlist_action.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
+        super(null, BASE.API+'playlist_action', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
       }
     };
     action.formDataMap.append('method', 'sounds');

--- a/frontend/src/page.js
+++ b/frontend/src/page.js
@@ -8,7 +8,7 @@ import { BASE } from './utilization/path';
  */
 export class AlbumCountAction extends BaseFrameWork.Network.RequestServerBase {
   constructor() {
-    super(null, BASE.API+'album_count_list.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.GET);
+    super(null, BASE.API+'album_count_list', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.GET);
 
   }
 }
@@ -18,7 +18,7 @@ export class AlbumCountAction extends BaseFrameWork.Network.RequestServerBase {
  */
 export class SoundSearchAction extends BaseFrameWork.Network.RequestServerBase {
   constructor() {
-    super(null, BASE.API+'sound_search.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
+    super(null, BASE.API+'sound_search', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
 
   }
 }
@@ -28,7 +28,7 @@ export class SoundSearchAction extends BaseFrameWork.Network.RequestServerBase {
  */
 export class AlbumSoundListAction extends BaseFrameWork.Network.RequestServerBase {
   constructor() {
-    super(null, BASE.API+'album_sounds.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.GET);
+    super(null, BASE.API+'album_sounds', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.GET);
   }
 }
 
@@ -37,7 +37,7 @@ export class AlbumSoundListAction extends BaseFrameWork.Network.RequestServerBas
  */
 export class SiteStatus extends BaseFrameWork.Network.RequestServerBase {
   constructor() {
-    super(null, BASE.API+'site_status.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
+    super(null, BASE.API+'site_status', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
   }
 }
 
@@ -46,7 +46,7 @@ export class SiteStatus extends BaseFrameWork.Network.RequestServerBase {
  */
 export class LockStatus extends BaseFrameWork.Network.RequestServerBase {
   constructor() {
-    super(null, BASE.API+'lock_status.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
+    super(null, BASE.API+'lock_status', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
   }
 }
 
@@ -56,7 +56,7 @@ export class LockStatus extends BaseFrameWork.Network.RequestServerBase {
  */
 export class SoundInfomation extends BaseFrameWork.Network.RequestServerBase {
   constructor() {
-    super(null, BASE.API+'sound_data.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.GET);
+    super(null, BASE.API+'sound_data', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.GET);
   }
 }
 
@@ -65,7 +65,7 @@ export class SoundInfomation extends BaseFrameWork.Network.RequestServerBase {
  */
 export class SoundAddTimeListAction extends BaseFrameWork.Network.RequestServerBase {
   constructor() {
-    super(null, BASE.API+'sound_addtime_list.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
+    super(null, BASE.API+'sound_addtime_list', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
   }
 }
 
@@ -74,7 +74,7 @@ export class SoundAddTimeListAction extends BaseFrameWork.Network.RequestServerB
  */
 export class AlbumListAction extends BaseFrameWork.Network.RequestServerBase {
   constructor() {
-    super(null, BASE.API+'album_list.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
+    super(null, BASE.API+'album_list', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
   }
 }
 
@@ -83,7 +83,7 @@ export class AlbumListAction extends BaseFrameWork.Network.RequestServerBase {
  */
 export class ArtistListAction extends BaseFrameWork.Network.RequestServerBase {
   constructor() {
-    super(null, BASE.API+'artist_list.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
+    super(null, BASE.API+'artist_list', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
   }
 }
 
@@ -92,7 +92,7 @@ export class ArtistListAction extends BaseFrameWork.Network.RequestServerBase {
  */
 export class ArtistSoundListAction extends BaseFrameWork.Network.RequestServerBase {
   constructor() {
-    super(null, BASE.API+'artist_sounds.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
+    super(null, BASE.API+'artist_sounds', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
   }
 }
 
@@ -101,7 +101,7 @@ export class ArtistSoundListAction extends BaseFrameWork.Network.RequestServerBa
  */
 export class GetSetting extends BaseFrameWork.Network.RequestServerBase {
   constructor() {
-    super(null, BASE.API+'get_setting.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.GET);
+    super(null, BASE.API+'get_setting', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.GET);
   }
 }
 
@@ -110,7 +110,7 @@ export class GetSetting extends BaseFrameWork.Network.RequestServerBase {
  */
 export class UpdateSetting extends BaseFrameWork.Network.RequestServerBase {
   constructor() {
-    super(null, BASE.API+'update_setting.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
+    super(null, BASE.API+'update_setting', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
   }
 }
 
@@ -119,7 +119,7 @@ export class UpdateSetting extends BaseFrameWork.Network.RequestServerBase {
  */
 export class SoundRegistAction extends BaseFrameWork.Network.RequestServerBase {
   constructor() {
-    super(null, BASE.API+'sound_regist.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
+    super(null, BASE.API+'sound_regist', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
   }
 }
 
@@ -128,7 +128,7 @@ export class SoundRegistAction extends BaseFrameWork.Network.RequestServerBase {
  */
 export class UpdateSoundInfomationAction extends BaseFrameWork.Network.RequestServerBase {
   constructor() {
-    super(null, BASE.API+'sound_regist.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.GET);
+    super(null, BASE.API+'sound_regist', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.GET);
   }
 }
 
@@ -137,7 +137,7 @@ export class UpdateSoundInfomationAction extends BaseFrameWork.Network.RequestSe
  */
 export class SetupDataBase extends BaseFrameWork.Network.RequestServerBase {
   constructor() {
-    super(null, BASE.API+'setup_database_table.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
+    super(null, BASE.API+'setup_database_table', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.POST);
   }
 }
 
@@ -146,8 +146,7 @@ export class SetupDataBase extends BaseFrameWork.Network.RequestServerBase {
  */
 export class SoundPlayedAction extends BaseFrameWork.Network.RequestServerBase {
   constructor() {
-    super(null, BASE.API+'action/sound_played.php', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.GET);
+    super(null, BASE.API+'action/sound_played', BaseFrameWork.Network.HttpResponseType.JSON, BaseFrameWork.Network.HttpRequestType.GET);
   }
 }
-
 


### PR DESCRIPTION
## Summary

- Registers the Node backend with extensionless Express routes such as `/api/get_setting` and `/sound_create/sound`.
- Updates frontend API/media calls away from legacy `.php` endpoint names.
- Keeps generated `.php` route aliases on the backend for backward compatibility while the primary route names are extensionless.

## Notes

- Target branch is `main`.
- The previously provided validation server was not touched.
- The local checkout could not push through git auth, so this PR branch was assembled through the GitHub connector.

## Validation

- GitHub Actions on `7470bade02618a395387089541bba13fb2809c0e`: all succeeded.
  - MariaDB Initial SQL Test: success
  - NodeJS with Webpack: success
  - Docker Image CI: success
  - Backend Contract: success