### PR TITLE
Fix App unmount lifecycle hook

### DIFF
--- a/frontend/src/layout/app/App.vue
+++ b/frontend/src/layout/app/App.vue
@@ -34,7 +34,7 @@ export default {
     this.updateControllerHeight();
     window.addEventListener('resize', this.updateControllerHeight);
   },
-  beforeDestroy() {
+  beforeUnmount() {
     window.removeEventListener('resize', this.updateControllerHeight);
   },
   methods: {


### PR DESCRIPTION
## Summary
- Rename the Vue 2 `beforeDestroy` lifecycle hook to Vue 3 `beforeUnmount` in `App.vue`
- Ensure the resize listener cleanup runs when the root app component unmounts

## Verification
- `npm run build --prefix frontend`
- GitHub Actions on `a4f099f5c758fc255fb145166dcdb9893c5f690a`: all succeeded
  - MariaDB Initial SQL Test: success
  - Docker Image CI: success
  - NodeJS with Webpack: success